### PR TITLE
Pin futures to 3.1.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ tqdm
 pip-tools
 twine
 lyft-requests==1.6.0
+futures==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ docutils==0.14            # via botocore, readme-renderer
 enum34==1.1.6
 flagpole==1.0.1           # via cloudaux
 future==0.16.0            # via readme-renderer
-futures==3.2.0            # via s3transfer
+futures==3.1.1
 html5lib==1.0.1           # via bleach
 idna==2.7
 import-string==0.1.0


### PR DESCRIPTION
Build is failing because:
Collecting futures==3.2.0 (from -r /tmp/src/requirements.txt (line 25))
  Could not find a version that satisfies the requirement futures==3.2.0 (from -r /tmp/src/requirements.txt (line 25)) (from versions: 0.2.python3, 0.1, 0.2, 1.0, 2.0, 2.1, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.6, 2.2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.1.0, 3.1.1)
No matching distribution found for futures==3.2.0 (from -r /tmp/src/requirements.txt (line 25))