### PR TITLE
Undo check dynamo resource validity check for every transaction

### DIFF
--- a/repokid/__init__.py
+++ b/repokid/__init__.py
@@ -19,7 +19,7 @@ import os
 
 import import_string
 
-__version__ = '0.9.0.post6'
+__version__ = '0.9.0.post7'
 
 
 def init_config():

--- a/repokid/utils/dynamo.py
+++ b/repokid/utils/dynamo.py
@@ -7,7 +7,6 @@ import boto3
 from botocore.exceptions import ClientError as BotoClientError
 from cloudaux.aws.sts import boto3_cached_conn as boto3_cached_conn
 
-from repokid import CONFIG
 from repokid import LOGGER as LOGGER
 
 # used as a placeholder for empty SID to work around this: https://github.com/aws/aws-sdk-js/issues/833
@@ -25,8 +24,7 @@ def catch_boto_error(func):
 
 
 @catch_boto_error
-def add_to_end_of_list(role_id, field_name, object_to_add):
-    dynamo_table = dynamo_get_or_create_table()
+def add_to_end_of_list(dynamo_table, role_id, field_name, object_to_add):
     dynamo_table.update_item(Key={'RoleId': role_id},
                              UpdateExpression=("SET #updatelist = list_append(if_not_exists(#updatelist,"
                                                ":empty_list), :object_to_add)"),
@@ -36,7 +34,7 @@ def add_to_end_of_list(role_id, field_name, object_to_add):
                                                             object_to_add)]})
 
 
-def dynamo_get_or_create_table():
+def dynamo_get_or_create_table(**dynamo_config):
     """
     Create a new table or get a reference to an existing Dynamo table named 'repokid_roles' that will store data all
     data for Repokid.  Return a table with a reference to the dynamo resource
@@ -52,13 +50,6 @@ def dynamo_get_or_create_table():
     Returns:
         dynamo_table object
     """
-
-    if not CONFIG:
-        config = _generate_default_config()
-    else:
-        config = CONFIG
-
-    dynamo_config = config['dynamo_db']
     if os.getenv('SERVICE_INSTANCE') == 'development':
         resource = boto3.resource('dynamodb',
                                   region_name='us-east-1',
@@ -144,7 +135,7 @@ def dynamo_get_or_create_table():
     return table
 
 
-def find_role_in_cache(account_number, role_name):
+def find_role_in_cache(dynamo_table, account_number, role_name):
     """Return role dictionary for active role with name in account
 
     Args:
@@ -154,7 +145,6 @@ def find_role_in_cache(account_number, role_name):
     Returns:
         string: RoleID for active role with name in given account, else None
     """
-    dynamo_table = dynamo_get_or_create_table()
     results = dynamo_table.query(IndexName='RoleName',
                                  KeyConditionExpression='RoleName = :rn',
                                  ExpressionAttributeValues={':rn': role_name})
@@ -162,7 +152,7 @@ def find_role_in_cache(account_number, role_name):
 
     if len(role_id_candidates) > 1:
         for role_id in role_id_candidates:
-            role_data = get_role_data(role_id, fields=['Account', 'Active'])
+            role_data = get_role_data(dynamo_table, role_id, fields=['Account', 'Active'])
             if role_data['Account'] == account_number and role_data['Active']:
                 return role_id
     elif len(role_id_candidates) == 1:
@@ -172,7 +162,7 @@ def find_role_in_cache(account_number, role_name):
 
 
 @catch_boto_error
-def get_role_data(roleID, fields=None):
+def get_role_data(dynamo_table, roleID, fields=None):
     """
     Get role data as a dictionary for a given role by ID
 
@@ -182,7 +172,6 @@ def get_role_data(roleID, fields=None):
     Returns:
         dict: data for the role if it exists, else None
     """
-    dynamo_table = dynamo_get_or_create_table()
     if fields:
         response = dynamo_table.get_item(Key={'RoleId': roleID}, AttributesToGet=fields)
     else:
@@ -193,7 +182,7 @@ def get_role_data(roleID, fields=None):
 
 
 @catch_boto_error
-def role_ids_for_account(account_number):
+def role_ids_for_account(dynamo_table, account_number):
     """
     Get a list of all role IDs in a given account by querying the Dynamo secondary index 'account'
 
@@ -203,7 +192,6 @@ def role_ids_for_account(account_number):
     Returns:
         list: role ids in given account
     """
-    dynamo_table = dynamo_get_or_create_table()
     role_ids = set()
 
     results = dynamo_table.query(IndexName='Account',
@@ -221,7 +209,7 @@ def role_ids_for_account(account_number):
 
 
 @catch_boto_error
-def role_ids_for_all_accounts():
+def role_ids_for_all_accounts(dynamo_table):
     """
     Get a list of all role IDs for all accounts by scanning the Dynamo table
 
@@ -231,7 +219,6 @@ def role_ids_for_all_accounts():
     Returns:
         list: role ids in all accounts
     """
-    dynamo_table = dynamo_get_or_create_table()
     role_ids = []
 
     response = dynamo_table.scan(ProjectionExpression='RoleId')
@@ -245,8 +232,7 @@ def role_ids_for_all_accounts():
 
 
 @catch_boto_error
-def set_role_data(role_id, update_keys):
-    dynamo_table = dynamo_get_or_create_table()
+def set_role_data(dynamo_table, role_id, update_keys):
     if not update_keys:
         return
 
@@ -272,7 +258,7 @@ def set_role_data(role_id, update_keys):
                              ExpressionAttributeValues=expression_attribute_values)
 
 
-def store_initial_role_data(arn, create_date, role_id, role_name, account_number, current_policy):
+def store_initial_role_data(dynamo_table, arn, create_date, role_id, role_name, account_number, current_policy):
     """
     Store the initial version of a role in Dynamo
 
@@ -283,7 +269,6 @@ def store_initial_role_data(arn, create_date, role_id, role_name, account_number
     Returns:
         None
     """
-    dynamo_table = dynamo_get_or_create_table()
     policy_entry = {'Source': 'Scan', 'Discovered': datetime.datetime.utcnow().isoformat(), 'Policy': current_policy}
 
     role_dict = {'Arn': arn, 'CreateDate': create_date.isoformat(), 'RoleId': role_id, 'RoleName': role_name,

--- a/repokid/utils/roledata.py
+++ b/repokid/utils/roledata.py
@@ -40,7 +40,7 @@ class RepoablePermissionDecision(object):
         return('Is repoable: {}, Decider: {}'.format(self.repoable, self.decider))
 
 
-def add_new_policy_version(role, current_policy, update_source):
+def add_new_policy_version(dynamo_table, role, current_policy, update_source):
     """
     Create a new entry in the history of policy versions in Dynamo. The entry contains the source of the new policy:
     (scan, repo, or restore) the current time, and the current policy contents. Updates the role's policies with the
@@ -57,11 +57,11 @@ def add_new_policy_version(role, current_policy, update_source):
     policy_entry = {'Source': update_source, 'Discovered': datetime.datetime.utcnow().isoformat(),
                     'Policy': current_policy}
 
-    add_to_end_of_list(role.role_id, 'Policies', policy_entry)
-    role.policies = get_role_data(role.role_id, fields=['Policies'])['Policies']
+    add_to_end_of_list(dynamo_table, role.role_id, 'Policies', policy_entry)
+    role.policies = get_role_data(dynamo_table, role.role_id, fields=['Policies'])['Policies']
 
 
-def find_and_mark_inactive(account_number, active_roles):
+def find_and_mark_inactive(dynamo_table, account_number, active_roles):
     """
     Mark roles in the account that aren't currently active inactive. Do this by getting all roles in the account and
     subtracting the active roles, any that are left are inactive and should be marked thusly.
@@ -75,13 +75,13 @@ def find_and_mark_inactive(account_number, active_roles):
     """
 
     active_roles = set(active_roles)
-    known_roles = set(role_ids_for_account(account_number))
+    known_roles = set(role_ids_for_account(dynamo_table, account_number))
     inactive_roles = known_roles - active_roles
 
     for roleID in inactive_roles:
-        role_dict = get_role_data(roleID, fields=['Active', 'Arn'])
+        role_dict = get_role_data(dynamo_table, roleID, fields=['Active', 'Arn'])
         if role_dict.get('Active'):
-            set_role_data(roleID, {'Active': False})
+            set_role_data(dynamo_table, roleID, {'Active': False})
 
 
 def find_newly_added_permissions(old_policy, new_policy):
@@ -101,7 +101,7 @@ def find_newly_added_permissions(old_policy, new_policy):
     return new_permissions - old_permissions
 
 
-def update_no_repo_permissions(role, newly_added_permissions):
+def update_no_repo_permissions(dynamo_table, role, newly_added_permissions):
     """
     Update Dyanmo entry for newly added permissions. Any that were newly detected get added with an expiration
     date of now plus the config setting for 'repo_requirements': 'exclude_new_permissions_for_days'. Expired entries
@@ -115,7 +115,7 @@ def update_no_repo_permissions(role, newly_added_permissions):
         None
     """
     current_ignored_permissions = get_role_data(
-        role.role_id, fields=['NoRepoPermissions']).get('NoRepoPermissions', {})
+        dynamo_table, role.role_id, fields=['NoRepoPermissions']).get('NoRepoPermissions', {})
     new_ignored_permissions = {}
 
     current_time = int(time.time())
@@ -131,10 +131,10 @@ def update_no_repo_permissions(role, newly_added_permissions):
         new_ignored_permissions[permission] = new_perms_expire_time
 
     role.no_repo_permissions = new_ignored_permissions
-    set_role_data(role.role_id, {'NoRepoPermissions': role.no_repo_permissions})
+    set_role_data(dynamo_table, role.role_id, {'NoRepoPermissions': role.no_repo_permissions})
 
 
-def update_opt_out(role):
+def update_opt_out(dynamo_table, role):
     """
     Update opt-out object for a role - remove (set to empty dict) any entries that have expired
     Opt-out objects should have the form {'expire': xxx, 'owner': xxx, 'reason': xxx}
@@ -146,10 +146,10 @@ def update_opt_out(role):
         None
     """
     if role.opt_out and int(role.opt_out['expire']) < int(time.time()):
-        set_role_data(role.role_id, {'OptOut': {}})
+        set_role_data(dynamo_table, role.role_id, {'OptOut': {}})
 
 
-def update_role_data(account_number, role, current_policy, source='Scan', add_no_repo=True):
+def update_role_data(dynamo_table, account_number, role, current_policy, source='Scan', add_no_repo=True):
     """
     Compare the current version of a policy for a role and what has been previously stored in Dynamo.
       - If current and new policy versions are different store the new version in Dynamo. Add any newly added
@@ -159,6 +159,7 @@ def update_role_data(account_number, role, current_policy, source='Scan', add_no
       - Updates the role with full history of policies, including current version
 
     Args:
+        dynamo_table
         account_number
         role (Role): current role being updated
         current_policy (dict): representation of the current policy version
@@ -169,9 +170,9 @@ def update_role_data(account_number, role, current_policy, source='Scan', add_no
     """
 
     # policy_entry: source, discovered, policy
-    stored_role = get_role_data(role.role_id, fields=['OptOut', 'Policies'])
+    stored_role = get_role_data(dynamo_table, role.role_id, fields=['OptOut', 'Policies'])
     if not stored_role:
-        role_dict = store_initial_role_data(role.arn, role.create_date, role.role_id, role.role_name,
+        role_dict = store_initial_role_data(dynamo_table, role.arn, role.create_date, role.role_id, role.role_name,
                                             account_number, current_policy)
         role.set_attributes(role_dict)
         LOGGER.info('Added new role ({}): {}'.format(role.role_id, role.arn))
@@ -179,7 +180,7 @@ def update_role_data(account_number, role, current_policy, source='Scan', add_no
         # is the policy list the same as the last we had?
         old_policy = stored_role['Policies'][-1]['Policy']
         if current_policy != old_policy:
-            add_new_policy_version(role, current_policy, source)
+            add_new_policy_version(dynamo_table, role, current_policy, source)
             LOGGER.info('{} has different inline policies than last time, adding to role store'.format(role.arn))
 
             newly_added_permissions = find_newly_added_permissions(old_policy, current_policy)
@@ -187,18 +188,18 @@ def update_role_data(account_number, role, current_policy, source='Scan', add_no
             newly_added_permissions = set()
 
         if add_no_repo:
-            update_no_repo_permissions(role, newly_added_permissions)
-        update_opt_out(role)
-        set_role_data(role.role_id, {'Refreshed': datetime.datetime.utcnow().isoformat()})
+            update_no_repo_permissions(dynamo_table, role, newly_added_permissions)
+        update_opt_out(dynamo_table, role)
+        set_role_data(dynamo_table, role.role_id, {'Refreshed': datetime.datetime.utcnow().isoformat()})
 
         # Update all data from Dynamo except CreateDate (it's in the wrong format) and DQ_by (we're going to recalc)
-        current_role_data = get_role_data(role.role_id)
+        current_role_data = get_role_data(dynamo_table, role.role_id)
         current_role_data.pop('CreateDate', None)
         current_role_data.pop('DisqualifiedBy', None)
         role.set_attributes(current_role_data)
 
 
-def update_stats(roles, source='Scan'):
+def update_stats(dynamo_table, roles, source='Scan'):
     """
     Create a new stats entry for each role in a set of roles and add it to Dynamo
 
@@ -222,7 +223,7 @@ def update_stats(roles, source='Scan'):
 
         for item in ['DisqualifiedBy', 'PermissionsCount', 'RepoablePermissionsCount']:
             if new_stats.get(item) != cur_stats.get(item):
-                add_to_end_of_list(role.role_id, 'Stats', new_stats)
+                add_to_end_of_list(dynamo_table, role.role_id, 'Stats', new_stats)
 
 
 def _calculate_repo_scores(roles, minimum_age, hooks):


### PR DESCRIPTION
Checking for validity of a resource, and creating a new token when necessary and doing a table scan to retrieve the table has caused huge performance degradation (tools runs for more than 11 hours). We will be undoing the change, and instead find ways to optimize the tool performance to run the tool under the limit of 1 hour (with this change it takes little more than 1.5 hours).