### PR TITLE
Refactorator: Apply eliminateunnecessaryorca in repokid

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -19,14 +19,12 @@ deploy:
   - name: staging
     legacy: true
     role: lyftpypi-staging-iad-deploy
-    orca:
-      - region: iad
+    orca: []
   - name: production
     legacy: true
     role: lyftpypi-production-iad-deploy
     automatic: true
-    orca:
-      - region: iad
+    orca: []
 slack: '#security'
 notification_overrides:
   deploy:


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control run refactorator.run fix -i repokid -f eliminateunnecessaryorca
```
# eliminateunnecessaryorca
State of the world before this refactorator:
  - This project unnecessarily runs orca as part of its deploy steps

Intended state of the world after this refactorator:
  - This project no longer runs orca:
     - orca-specific deploy steps are removed
     - orca is turned off for other deploy steps.
  - Legacyorca facets are removed.


For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
